### PR TITLE
Fixed reference to Sonatype OSS Repo

### DIFF
--- a/trap-android/pom.xml
+++ b/trap-android/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-api/pom.xml
+++ b/trap-api/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-core/pom.xml
+++ b/trap-core/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-index-maven-plugin/pom.xml
+++ b/trap-index-maven-plugin/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-js/pom.xml
+++ b/trap-js/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-network/pom.xml
+++ b/trap-network/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-network/trap-network-nio/pom.xml
+++ b/trap-network/trap-network-nio/pom.xml
@@ -11,7 +11,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-network/trap-network-nio1/pom.xml
+++ b/trap-network/trap-network-nio1/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-network/trap-network-nio2/pom.xml
+++ b/trap-network/trap-network-nio2/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-network/trap-network-websockets-api/pom.xml
+++ b/trap-network/trap-network-websockets-api/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-network/trap-network-websockets-nio/pom.xml
+++ b/trap-network/trap-network-websockets-nio/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-network/trap-network-websockets-sockets/pom.xml
+++ b/trap-network/trap-network-websockets-sockets/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-packaging/pom.xml
+++ b/trap-packaging/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-packaging/trap-full/pom.xml
+++ b/trap-packaging/trap-full/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-tests/pom.xml
+++ b/trap-tests/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-tests/trap-tests-arquillian-parent/pom.xml
+++ b/trap-tests/trap-tests-arquillian-parent/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-tests/trap-tests-multiple-transports/pom.xml
+++ b/trap-tests/trap-tests-multiple-transports/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/default/trap-transport-http/pom.xml
+++ b/trap-transports/default/trap-transport-http/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/default/trap-transport-loopback/pom.xml
+++ b/trap-transports/default/trap-transport-loopback/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/default/trap-transport-socket/pom.xml
+++ b/trap-transports/default/trap-transport-socket/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/default/trap-transport-websocket/pom.xml
+++ b/trap-transports/default/trap-transport-websocket/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-client-apache/pom.xml
+++ b/trap-transports/http/http-client-apache/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-client-sun/pom.xml
+++ b/trap-transports/http/http-client-sun/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-server-servlet-2.5/pom.xml
+++ b/trap-transports/http/http-server-servlet-2.5/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-server-servlet-3.0/pom.xml
+++ b/trap-transports/http/http-server-servlet-3.0/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-server-sun/pom.xml
+++ b/trap-transports/http/http-server-sun/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-tests-servlet/pom.xml
+++ b/trap-transports/http/http-tests-servlet/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-tests-suite/pom.xml
+++ b/trap-transports/http/http-tests-suite/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-tests-sun/pom.xml
+++ b/trap-transports/http/http-tests-sun/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/http-utils-sun/pom.xml
+++ b/trap-transports/http/http-utils-sun/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/http/pom.xml
+++ b/trap-transports/http/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/loopback/pom.xml
+++ b/trap-transports/loopback/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/pom.xml
+++ b/trap-transports/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/socket/pom.xml
+++ b/trap-transports/socket/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/socket/socket-client-ernio/pom.xml
+++ b/trap-transports/socket/socket-client-ernio/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/socket/socket-constants/pom.xml
+++ b/trap-transports/socket/socket-constants/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/socket/socket-server-ernio/pom.xml
+++ b/trap-transports/socket/socket-server-ernio/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/socket/socket-tests/pom.xml
+++ b/trap-transports/socket/socket-tests/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/websocket/pom.xml
+++ b/trap-transports/websocket/pom.xml
@@ -14,7 +14,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/websocket/websocket-ernio/pom.xml
+++ b/trap-transports/websocket/websocket-ernio/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/websocket/websocket-netty/pom.xml
+++ b/trap-transports/websocket/websocket-netty/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-transports/websocket/websocket-tomcat/pom.xml
+++ b/trap-transports/websocket/websocket-tomcat/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-utils-15/pom.xml
+++ b/trap-utils-15/pom.xml
@@ -12,7 +12,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>

--- a/trap-utils-api/pom.xml
+++ b/trap-utils-api/pom.xml
@@ -13,7 +13,7 @@
 	<repositories>
 		<repository>
 			<id>trap-snapshots</id>
-			<url>https://oss.sonatype.com/content/repositories/snapshots</url>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>


### PR DESCRIPTION
The repo was incorrectly referenced as sonatype.com and not
sonatype.org. This fix allows SNAPSHOT dependencies of Trap to work
properly.